### PR TITLE
Feature/checkin

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -8,6 +8,7 @@ class RouteName {
   static const String Onboarding = '/onboarding';
   static const String Dashboard = '/dashboard';
   static const String Checkin = '/checkin';
+  static const String CheckinDone = '/checkin-done';
   static const String CheckinHistory = '/checkin-history';
 }
 
@@ -18,6 +19,7 @@ class RouteModule {
     RouteName.Onboarding: (context) => OnboardingScreen(),
     RouteName.Dashboard: (context) => DashboardScreen(),
     RouteName.Checkin: (context) => CheckinScreen(),
+    RouteName.CheckinDone: (context) => CheckinDoneScreen(),
     RouteName.CheckinHistory: (context) => CheckinHistoryScreen(),
   };
 }

--- a/lib/screens/checkin/checkin.dart
+++ b/lib/screens/checkin/checkin.dart
@@ -28,7 +28,8 @@ class _CheckinScreenState extends State<CheckinScreen> {
         appBar: SharedAppBar(
           title: const Text('Check-in'),
         ),
-        body: LayoutBuilder(builder: (BuildContext context, BoxConstraints viewportConstraints) {
+        body: LayoutBuilder(builder:
+            (BuildContext context, BoxConstraints viewportConstraints) {
           return SingleChildScrollView(
             child: Container(
               constraints: BoxConstraints(
@@ -93,14 +94,17 @@ class _CheckinScreenState extends State<CheckinScreen> {
       ),
       const SizedBox(height: Spacers.md),
       Wrap(
-        children: Symptom.values.map((s) => _buildSymptom(context, model, s)).toList(),
+        children: Symptom.values
+            .map((s) => _buildSymptom(context, model, s))
+            .toList(),
         runSpacing: 0,
         spacing: 12,
       ),
     ]);
   }
 
-  Widget _buildSymptom(BuildContext context, CheckinViewModel model, Symptom symptom) {
+  Widget _buildSymptom(
+      BuildContext context, CheckinViewModel model, Symptom symptom) {
     return ChoiceChip(
       label: Text(symptomLabelMap[symptom]),
       onSelected: (selected) {

--- a/lib/screens/checkin/checkin.dart
+++ b/lib/screens/checkin/checkin.dart
@@ -25,41 +25,35 @@ class _CheckinScreenState extends State<CheckinScreen> {
 
   Widget _buildScreen(BuildContext context, CheckinViewModel model) {
     return Scaffold(
-        appBar: SharedAppBar(
-          title: const Text('Check-in'),
-        ),
-        body: LayoutBuilder(builder:
-            (BuildContext context, BoxConstraints viewportConstraints) {
-          return SingleChildScrollView(
-            child: Container(
-              constraints: BoxConstraints(
-                minHeight: viewportConstraints.maxHeight,
-                minWidth: viewportConstraints.maxWidth,
-              ),
-              child: IntrinsicHeight(
-                child: Column(
-                  children: <Widget>[
-                    _buildTemp(context, model),
-                    const SizedBox(height: Spacers.xl),
-                    _buildSymptoms(context, model),
-                    const Spacer(flex: 1),
-                    SizedBox(
-                      width: double.infinity,
-                      child: ProgressButton(
-                          label: 'Submit',
-                          onPressed: () {
-                            _submit(context, model);
-                          },
-                          type: ProgressButtonType.Raised),
-                    )
-                  ],
-                  mainAxisSize: MainAxisSize.min,
-                ),
-              ),
-              padding: const EdgeInsets.all(16),
-            ),
+      appBar: SharedAppBar(
+        title: const Text('Check-in'),
+      ),
+      body: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints viewportConstraints) {
+          return ListView(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+            children: <Widget>[
+              _buildTemp(context, model),
+              const SizedBox(height: Spacers.xl),
+              _buildSymptomTitle(context, model),
+              ...Symptom.values
+                  .map((s) => _buildSymptom(context, model, s))
+                  .toList(),
+              SizedBox(
+                width: double.infinity,
+                child: ProgressButton(
+                    label: 'Submit',
+                    onPressed: () {
+                      _submit(context, model);
+                    },
+                    type: ProgressButtonType.Raised),
+              )
+            ],
           );
-        }));
+        },
+      ),
+    );
   }
 
   void _submit(BuildContext context, CheckinViewModel model) {
@@ -84,33 +78,30 @@ class _CheckinScreenState extends State<CheckinScreen> {
     );
   }
 
-  Widget _buildSymptoms(BuildContext context, CheckinViewModel model) {
+  Widget _buildSymptomTitle(BuildContext context, CheckinViewModel model) {
     return Column(children: [
-      Text('Symptoms', style: AppTypography.h2),
+      Text('Please select your symptoms', style: AppTypography.h2),
       Text(
-        'Please select the symptoms that you are experiencing:',
-        style: AppTypography.bodyBold,
+        //todo: extract prior day's symptoms. adjust padding
+        'Yesterday, you had cough, short of breath,\n and body aches',
+        style: AppTypography.bodyRegular1,
         textAlign: TextAlign.center,
       ),
-      const SizedBox(height: Spacers.md),
-      Wrap(
-        children: Symptom.values
-            .map((s) => _buildSymptom(context, model, s))
-            .toList(),
-        runSpacing: 0,
-        spacing: 12,
-      ),
+      const SizedBox(height: Spacers.lg),
     ]);
   }
 
   Widget _buildSymptom(
       BuildContext context, CheckinViewModel model, Symptom symptom) {
-    return ChoiceChip(
-      label: Text(symptomLabelMap[symptom]),
-      onSelected: (selected) {
-        model.toggleSelected(symptom);
-      },
-      selected: model.selectedSymptoms.contains(symptom),
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: InkWell(
+        child: SelectionCard(
+          title: symptomLabelMap[symptom],
+          selected: model.selectedSymptoms.contains(symptom),
+        ),
+        onTap: () => model.toggleSelected(symptom),
+      ),
     );
   }
 }

--- a/lib/screens/checkin/checkin.vm.dart
+++ b/lib/screens/checkin/checkin.vm.dart
@@ -6,6 +6,7 @@ import 'package:vital_circle/constants/log_zone.dart';
 import 'package:vital_circle/enums/symptoms.dart';
 import 'package:vital_circle/models/index.dart';
 import 'package:vital_circle/services/services.dart';
+import 'package:vital_circle/routes.dart';
 
 class CheckinViewModel extends ChangeNotifier {
   CheckinViewModel.of(BuildContext context)
@@ -38,19 +39,31 @@ class CheckinViewModel extends ChangeNotifier {
     final checkin = Checkin.empty();
     checkin.temp = temperature;
     checkin.symptoms = Symptoms.empty();
-    checkin.symptoms.febrile = _selectedSymptoms.contains(Symptom.Fever) ? 1 : 0;
+    checkin.symptoms.febrile =
+        _selectedSymptoms.contains(Symptom.Fever) ? 1 : 0;
     checkin.symptoms.cough = _selectedSymptoms.contains(Symptom.Cough) ? 1 : 0;
-    checkin.symptoms.shortnessOfBreath = _selectedSymptoms.contains(Symptom.ShortOfBreath) ? 1 : 0;
-    checkin.symptoms.feelingIll = _selectedSymptoms.contains(Symptom.FeelingIll) ? 1 : 0;
-    checkin.symptoms.headache = _selectedSymptoms.contains(Symptom.Headache) ? 1 : 0;
-    checkin.symptoms.bodyAches = _selectedSymptoms.contains(Symptom.BodyAches) ? 1 : 0;
-    checkin.symptoms.oddTaste = _selectedSymptoms.contains(Symptom.OddTaste) ? 1 : 0;
-    checkin.symptoms.oddSmell = _selectedSymptoms.contains(Symptom.OddSmell) ? 1 : 0;
-    checkin.symptoms.sneezing = _selectedSymptoms.contains(Symptom.Sneezing) ? 1 : 0;
-    checkin.symptoms.runnyNose = _selectedSymptoms.contains(Symptom.RunnyNose) ? 1 : 0;
-    checkin.symptoms.soreThroat = _selectedSymptoms.contains(Symptom.SoreThroat) ? 1 : 0;
-    checkin.symptoms.nauseaVomiting = _selectedSymptoms.contains(Symptom.NauseaVomiting) ? 1 : 0;
-    checkin.symptoms.diarrhea = _selectedSymptoms.contains(Symptom.Diarrhea) ? 1 : 0;
+    checkin.symptoms.shortnessOfBreath =
+        _selectedSymptoms.contains(Symptom.ShortOfBreath) ? 1 : 0;
+    checkin.symptoms.feelingIll =
+        _selectedSymptoms.contains(Symptom.FeelingIll) ? 1 : 0;
+    checkin.symptoms.headache =
+        _selectedSymptoms.contains(Symptom.Headache) ? 1 : 0;
+    checkin.symptoms.bodyAches =
+        _selectedSymptoms.contains(Symptom.BodyAches) ? 1 : 0;
+    checkin.symptoms.oddTaste =
+        _selectedSymptoms.contains(Symptom.OddTaste) ? 1 : 0;
+    checkin.symptoms.oddSmell =
+        _selectedSymptoms.contains(Symptom.OddSmell) ? 1 : 0;
+    checkin.symptoms.sneezing =
+        _selectedSymptoms.contains(Symptom.Sneezing) ? 1 : 0;
+    checkin.symptoms.runnyNose =
+        _selectedSymptoms.contains(Symptom.RunnyNose) ? 1 : 0;
+    checkin.symptoms.soreThroat =
+        _selectedSymptoms.contains(Symptom.SoreThroat) ? 1 : 0;
+    checkin.symptoms.nauseaVomiting =
+        _selectedSymptoms.contains(Symptom.NauseaVomiting) ? 1 : 0;
+    checkin.symptoms.diarrhea =
+        _selectedSymptoms.contains(Symptom.Diarrhea) ? 1 : 0;
     return checkin;
   }
 
@@ -65,7 +78,9 @@ class CheckinViewModel extends ChangeNotifier {
       final user = await _authService.user;
       final checkin = _getModel();
       _checkinApi.addCheckin(user.uid, checkin);
-      Navigator.of(context).pop();
+      Navigator.pushNamedAndRemoveUntil(context, RouteName.CheckinDone,
+          ModalRoute.withName(RouteName.Dashboard));
+      // Navigator.of(context).pop();
     } catch (_) {
       _isSaving = false;
       notifyListeners();

--- a/lib/screens/checkin/checkin_done.dart
+++ b/lib/screens/checkin/checkin_done.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class CheckinDoneScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text('Congrats!'),
+      ),
+    );
+  }
+}

--- a/lib/screens/checkin/checkin_feeling.dart
+++ b/lib/screens/checkin/checkin_feeling.dart
@@ -4,6 +4,7 @@ import 'package:vital_circle/themes/theme.dart';
 import 'package:vital_circle/themes/typography.dart';
 import 'package:vital_circle/routes.dart';
 
+import '../../themes/spacers.dart';
 import 'checkin.vm.dart';
 
 class CheckinFeeling extends StatefulWidget {
@@ -47,22 +48,32 @@ class _CheckinFeelingState extends State<CheckinFeeling>
       ),
       body: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints viewportConstraints) {
-          return ListView(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+          return Column(
+            mainAxisSize: MainAxisSize.max,
             children: <Widget>[
-              const SizedBox(height: Spacers.xl),
-              _buildHeader(context, model),
-              _buildItem(context, model, 0),
-              _buildItem(context, model, 1),
-              _buildItem(context, model, 2),
-              SizedBox(
-                width: double.infinity,
-                child: ProgressButton(
-                    label: 'Continue',
-                    onPressed: () => _continue(context, model),
-                    type: ProgressButtonType.Raised),
-              )
+              Expanded(
+                child: ListView(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: Spacers.md, vertical: Spacers.md),
+                  children: <Widget>[
+                    _buildHeader(context, model),
+                    _buildItem(context, model, 0),
+                    _buildItem(context, model, 1),
+                    _buildItem(context, model, 2),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: Spacers.md, vertical: Spacers.lg),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: ProgressButton(
+                      label: 'Continue',
+                      onPressed: () => _continue(context, model),
+                      type: ProgressButtonType.Raised),
+                ),
+              ),
             ],
           );
         },
@@ -94,6 +105,7 @@ class _CheckinFeelingState extends State<CheckinFeeling>
         ),
         onTap: () => setState(
           () {
+            // todo: extract into viewmodel
             feelingCheck[index] = !feelingCheck[index];
           },
         ),

--- a/lib/screens/checkin/checkin_feeling.dart
+++ b/lib/screens/checkin/checkin_feeling.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:vital_circle/shared/shared.dart';
+import 'package:vital_circle/themes/theme.dart';
+import 'package:vital_circle/themes/typography.dart';
+import 'package:vital_circle/routes.dart';
+
+import 'checkin.vm.dart';
+
+class CheckinFeeling extends StatefulWidget {
+  @override
+  _CheckinFeelingState createState() => _CheckinFeelingState();
+}
+
+class _CheckinFeelingState extends State<CheckinFeeling>
+    with AutomaticKeepAliveClientMixin {
+  //todo: extract into data model
+  List<String> feeling = [
+    'Better than ever!',
+    'Pretty similar to yesterday.',
+    'Worse than yesterday.'
+  ];
+  List<bool> feelingCheck = [false, false, false];
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return BaseWidget<CheckinViewModel>(
+      model: CheckinViewModel.of(context),
+      builder: (context, model, child) {
+        return _buildScreen(context, model);
+      },
+    );
+  }
+
+  Widget _buildScreen(BuildContext context, CheckinViewModel model) {
+    return Scaffold(
+      appBar: SharedAppBar(
+        title: const Text('Check-in'),
+        // empty container used to hide back button
+        leading: Container(),
+        actions: <Widget>[
+          IconButton(
+              icon: Icon(Icons.close),
+              onPressed: () => Navigator.popUntil(
+                  context, ModalRoute.withName(RouteName.Dashboard)))
+        ],
+      ),
+      body: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints viewportConstraints) {
+          return ListView(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+            children: <Widget>[
+              const SizedBox(height: Spacers.xl),
+              _buildHeader(context, model),
+              _buildItem(context, model, 0),
+              _buildItem(context, model, 1),
+              _buildItem(context, model, 2),
+              SizedBox(
+                width: double.infinity,
+                child: ProgressButton(
+                    label: 'Continue',
+                    onPressed: () => _continue(context, model),
+                    type: ProgressButtonType.Raised),
+              )
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, CheckinViewModel model) {
+    return Column(children: [
+      Text('How are you feeling today?', style: AppTypography.h2),
+      const SizedBox(height: Spacers.sm),
+      Text(
+        //todo: extract prior day's symptoms. adjust padding
+        'Yesterday, you felt worse',
+        style: AppTypography.bodyRegular1,
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: Spacers.lg),
+    ]);
+  }
+
+  Widget _buildItem(BuildContext context, CheckinViewModel model, int index) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: InkWell(
+        child: SelectionCard(
+          title: feeling[index],
+          selected: feelingCheck[index],
+        ),
+        onTap: () => setState(
+          () {
+            feelingCheck[index] = !feelingCheck[index];
+          },
+        ),
+      ),
+    );
+  }
+
+  void _continue(BuildContext context, CheckinViewModel model) {
+    // dismiss keyboard
+    FocusScope.of(context).requestFocus(FocusNode());
+    // todo: implement checkin.onNext
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}

--- a/lib/screens/checkin/checkin_symptoms.dart
+++ b/lib/screens/checkin/checkin_symptoms.dart
@@ -43,23 +43,33 @@ class _CheckinSymptomsState extends State<CheckinSymptoms>
       ),
       body: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints viewportConstraints) {
-          return ListView(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+          return Column(
+            mainAxisSize: MainAxisSize.max,
             children: <Widget>[
-              const SizedBox(height: Spacers.xl),
-              _buildHeader(context, model),
-              ...Symptom.values
-                  .map((s) => _buildSymptom(context, model, s))
-                  .toList(),
-              SizedBox(
-                width: double.infinity,
-                child: ProgressButton(
-                    label: 'Submit',
-                    onPressed: () {
-                      _submit(context, model);
-                    },
-                    type: ProgressButtonType.Raised),
+              Expanded(
+                child: ListView(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: Spacers.md, vertical: Spacers.md),
+                  children: <Widget>[
+                    _buildHeader(context, model),
+                    ...Symptom.values
+                        .map((s) => _buildSymptom(context, model, s))
+                        .toList(),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: Spacers.md, vertical: Spacers.lg),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: ProgressButton(
+                      label: 'Submit',
+                      onPressed: () {
+                        _submit(context, model);
+                      },
+                      type: ProgressButtonType.Raised),
+                ),
               )
             ],
           );

--- a/lib/screens/checkin/checkin_symptoms.dart
+++ b/lib/screens/checkin/checkin_symptoms.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:vital_circle/enums/symptoms.dart';
+import 'package:vital_circle/shared/shared.dart';
+import 'package:vital_circle/themes/theme.dart';
+import 'package:vital_circle/themes/typography.dart';
+import 'package:vital_circle/utils/symptom_label.dart';
+
+import 'checkin.vm.dart';
+
+class CheckinSymptoms extends StatefulWidget {
+  @override
+  _CheckinSymptomsState createState() => _CheckinSymptomsState();
+}
+
+class _CheckinSymptomsState extends State<CheckinSymptoms>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return BaseWidget<CheckinViewModel>(
+      model: CheckinViewModel.of(context),
+      builder: (context, model, child) {
+        return _buildScreen(context, model);
+      },
+    );
+  }
+
+  Widget _buildScreen(BuildContext context, CheckinViewModel model) {
+    return Scaffold(
+      appBar: SharedAppBar(
+        title: const Text('Check-in'),
+        leading: BackButton(
+          onPressed: () {
+            // todo: implement checkin.onPrevious
+          },
+        ),
+        actions: <Widget>[
+          IconButton(
+              icon: Icon(Icons.close),
+              onPressed: () => Navigator.popUntil(
+                  context, ModalRoute.withName('/dashboard')))
+        ],
+      ),
+      body: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints viewportConstraints) {
+          return ListView(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+            children: <Widget>[
+              const SizedBox(height: Spacers.xl),
+              _buildHeader(context, model),
+              ...Symptom.values
+                  .map((s) => _buildSymptom(context, model, s))
+                  .toList(),
+              SizedBox(
+                width: double.infinity,
+                child: ProgressButton(
+                    label: 'Submit',
+                    onPressed: () {
+                      _submit(context, model);
+                    },
+                    type: ProgressButtonType.Raised),
+              )
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  void _submit(BuildContext context, CheckinViewModel model) {
+    // dismiss keyboard
+    FocusScope.of(context).requestFocus(FocusNode());
+    model.submit(context);
+  }
+
+  Widget _buildHeader(BuildContext context, CheckinViewModel model) {
+    return Column(children: [
+      Text('Please select your symptoms', style: AppTypography.h2),
+      const SizedBox(height: Spacers.sm),
+      Text(
+        //todo: extract prior day's symptoms. adjust padding
+        'Yesterday, you had cough, short of breath,\n and body aches',
+        style: AppTypography.bodyRegular1,
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: Spacers.lg),
+    ]);
+  }
+
+  Widget _buildSymptom(
+      BuildContext context, CheckinViewModel model, Symptom symptom) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: InkWell(
+        child: SelectionCard(
+          title: symptomLabelMap[symptom],
+          selected: model.selectedSymptoms.contains(symptom),
+        ),
+        onTap: () => model.toggleSelected(symptom),
+      ),
+    );
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}

--- a/lib/screens/checkin/checkin_temperature.dart
+++ b/lib/screens/checkin/checkin_temperature.dart
@@ -5,6 +5,7 @@ import 'package:vital_circle/themes/typography.dart';
 import 'package:vital_circle/routes.dart';
 
 import 'checkin.vm.dart';
+import 'checkin.vm.dart';
 
 class CheckinTemperature extends StatefulWidget {
   @override
@@ -13,6 +14,10 @@ class CheckinTemperature extends StatefulWidget {
 
 class _CheckinTemperatureState extends State<CheckinTemperature>
     with AutomaticKeepAliveClientMixin {
+  //todo: extract into data model
+  List<String> subjectiveTemp = ['Feeling hot', 'Feeling fine', 'Unsure'];
+  List<bool> subjectiveTempCheck = [false, false, false];
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -42,20 +47,29 @@ class _CheckinTemperatureState extends State<CheckinTemperature>
       ),
       body: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints viewportConstraints) {
-          return ListView(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+          return Column(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
-              _buildHeader(context, model),
-              const SizedBox(height: Spacers.xl),
-              _buildTemp(context, model),
-              const SizedBox(height: Spacers.xl),
-              SizedBox(
-                width: double.infinity,
-                child: ProgressButton(
-                    label: 'Continue',
-                    onPressed: () => _continue(context, model),
-                    type: ProgressButtonType.Raised),
+              Padding(
+                padding: const EdgeInsets.only(top: Spacers.md),
+                child: _buildHeader(context, model),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: Spacers.md),
+                child: _buildTemp(context, model),
+              ),
+              _buildSubjectiveTemp(context, model),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: Spacers.md, vertical: Spacers.lg),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: ProgressButton(
+                      label: 'Continue',
+                      onPressed: () => _continue(context, model),
+                      type: ProgressButtonType.Raised),
+                ),
               )
             ],
           );
@@ -91,6 +105,42 @@ class _CheckinTemperatureState extends State<CheckinTemperature>
         model.temperature = double.tryParse(value);
       },
       textInputAction: TextInputAction.done,
+    );
+  }
+
+  Widget _buildSubjectiveTemp(BuildContext context, CheckinViewModel model) {
+    return Column(
+      children: <Widget>[
+        const Text('No thermometer?'),
+        const SizedBox(height: Spacers.sm),
+        Wrap(
+          // crossAxisAlignment: WrapCrossAlignment.center,
+          alignment: WrapAlignment.center,
+          children: <Widget>[
+            _buildItem(context, model, 0),
+            _buildItem(context, model, 1),
+            _buildItem(context, model, 2),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildItem(BuildContext context, CheckinViewModel model, int index) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: InkWell(
+        child: SelectionCardSmall(
+          title: subjectiveTemp[index],
+          selected: subjectiveTempCheck[index],
+        ),
+        onTap: () => setState(
+          () {
+            // todo: extract into viewmodel
+            subjectiveTempCheck[index] = !subjectiveTempCheck[index];
+          },
+        ),
+      ),
     );
   }
 

--- a/lib/screens/checkin/checkin_temperature.dart
+++ b/lib/screens/checkin/checkin_temperature.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:vital_circle/shared/shared.dart';
+import 'package:vital_circle/themes/theme.dart';
+import 'package:vital_circle/themes/typography.dart';
+import 'package:vital_circle/routes.dart';
+
+import 'checkin.vm.dart';
+
+class CheckinTemperature extends StatefulWidget {
+  @override
+  _CheckinTemperatureState createState() => _CheckinTemperatureState();
+}
+
+class _CheckinTemperatureState extends State<CheckinTemperature>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return BaseWidget<CheckinViewModel>(
+      model: CheckinViewModel.of(context),
+      builder: (context, model, child) {
+        return _buildScreen(context, model);
+      },
+    );
+  }
+
+  Widget _buildScreen(BuildContext context, CheckinViewModel model) {
+    return Scaffold(
+      appBar: SharedAppBar(
+        title: const Text('Check-in'),
+        leading: BackButton(
+          onPressed: () {
+            // todo: implement checkin.onPrevious
+          },
+        ),
+        actions: <Widget>[
+          IconButton(
+              icon: Icon(Icons.close),
+              onPressed: () => Navigator.popUntil(
+                  context, ModalRoute.withName(RouteName.Dashboard)))
+        ],
+      ),
+      body: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints viewportConstraints) {
+          return ListView(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+            children: <Widget>[
+              _buildHeader(context, model),
+              const SizedBox(height: Spacers.xl),
+              _buildTemp(context, model),
+              const SizedBox(height: Spacers.xl),
+              SizedBox(
+                width: double.infinity,
+                child: ProgressButton(
+                    label: 'Continue',
+                    onPressed: () => _continue(context, model),
+                    type: ProgressButtonType.Raised),
+              )
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, CheckinViewModel model) {
+    return Column(children: [
+      Text('What is your temperature?', style: AppTypography.h2),
+      const SizedBox(height: Spacers.sm),
+      Text(
+        //todo: extract prior day's symptoms. adjust padding
+        'Yesterday, you recorded 100.4 °F',
+        style: AppTypography.bodyRegular1,
+        textAlign: TextAlign.center,
+      ),
+      const SizedBox(height: Spacers.lg),
+    ]);
+  }
+
+  Widget _buildTemp(BuildContext context, CheckinViewModel model) {
+    return TextFormField(
+      decoration: const InputDecoration(
+        labelText: 'Temperature',
+        border: OutlineInputBorder(),
+        suffix: Text('°F'),
+      ),
+      keyboardType: TextInputType.number,
+      initialValue: '',
+      onSaved: (value) {
+        model.temperature = double.tryParse(value);
+      },
+      textInputAction: TextInputAction.done,
+    );
+  }
+
+  void _continue(BuildContext context, CheckinViewModel model) {
+    // dismiss keyboard
+    FocusScope.of(context).requestFocus(FocusNode());
+    model.submit(context);
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}

--- a/lib/screens/checkin_history/checkin_history.vm.dart
+++ b/lib/screens/checkin_history/checkin_history.vm.dart
@@ -5,8 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:vital_circle/models/index.dart';
-
-import '../../services/services.dart';
+import 'package:vital_circle/services/services.dart';
 
 class CheckinHistoryViewModel extends ChangeNotifier {
   CheckinHistoryViewModel.of(BuildContext context)
@@ -26,7 +25,10 @@ class CheckinHistoryViewModel extends ChangeNotifier {
 
   Future onInit() async {
     final user = await _authService.user;
-    _checkinSub = _checkinApi.streamCheckins(user.uid).where((x) => x != null).listen((checkins) {
+    _checkinSub = _checkinApi
+        .streamCheckins(user.uid)
+        .where((x) => x != null)
+        .listen((checkins) {
       _isReady = true;
       _checkins = checkins;
       notifyListeners();

--- a/lib/screens/dashboard/dashboard.dart
+++ b/lib/screens/dashboard/dashboard.dart
@@ -45,21 +45,22 @@ class DashboardScreen extends StatelessWidget {
           _buildGreeting(),
           const SizedBox(height: Spacers.lg),
           model.hasCheckedInToday
-              ? _buildCard(context, Icons.check_circle, 'Thank you for checking in today!')
-              : _buildCard(
-                  context,
-                  Icons.check_circle_outline,
-                  'Check-in',
-                  'Log your symptoms and temperature.',
-                  RouteName.Checkin,
+              ? NavigationCard(
+                  title: 'Thank you for checking in today!',
+                  icon: Icons.check_circle,
+                )
+              : NavigationCard(
+                  title: 'Check-in',
+                  subtitle: 'Log your symptoms and temperature.',
+                  icon: Icons.check_circle_outline,
+                  routeName: RouteName.Checkin,
                 ),
           const SizedBox(height: Spacers.md),
-          _buildCard(
-            context,
-            Icons.calendar_today,
-            'History',
-            'Look at your previous symptoms and edit records.',
-            RouteName.CheckinHistory,
+          NavigationCard(
+            title: 'History',
+            subtitle: 'Look at your previous symptoms and edit records.',
+            icon: Icons.calendar_today,
+            routeName: RouteName.CheckinHistory,
           )
         ],
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -72,41 +73,6 @@ class DashboardScreen extends StatelessWidget {
     return Text(
       'Good day, Human',
       style: AppTypography.h1,
-    );
-  }
-
-  Widget _buildCard(BuildContext context, IconData icon, String title, [String subtitle, String routeName]) {
-    return InkWell(
-      child: Container(
-        decoration: BoxDecoration(
-          border: Border.all(color: AppColors.cardBorder),
-          borderRadius: const BorderRadius.all(Radius.circular(16)),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Icon(icon),
-            const SizedBox(width: 16),
-            Expanded(
-              flex: 1,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(title, style: AppTypography.bodyBold),
-                  const SizedBox(height: 4),
-                  if (subtitle != null) WrappedText(child: Text(subtitle)),
-                ],
-              ),
-            )
-          ],
-        ),
-        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
-      ),
-      onTap: routeName == null
-          ? null
-          : () {
-              Navigator.of(context).pushNamed(routeName);
-            },
     );
   }
 }

--- a/lib/screens/dashboard/dashboard.vm.dart
+++ b/lib/screens/dashboard/dashboard.vm.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
-import '../../services/services.dart';
+import 'package:vital_circle/services/services.dart';
 
 class DashboardViewModel extends ChangeNotifier {
   DashboardViewModel.of(BuildContext context)
@@ -35,7 +35,9 @@ class DashboardViewModel extends ChangeNotifier {
     final start = DateTime(now.year, now.month, now.day);
     final end = DateTime(now.year, now.month, now.day, 23, 59, 59, 1000, 1000);
     final user = await _authService.user;
-    _dailyCheckinSubscription = _checkinApi.streamCheckinsForTimeRange(user.uid, start, end).listen((checkins) {
+    _dailyCheckinSubscription = _checkinApi
+        .streamCheckinsForTimeRange(user.uid, start, end)
+        .listen((checkins) {
       _hasCheckedInToday = checkins.isNotEmpty;
       _isReady = true;
       notifyListeners();

--- a/lib/screens/onboarding/legal.dart
+++ b/lib/screens/onboarding/legal.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:vital_circle/themes/typography.dart';
 
-import '../../shared/shared.dart';
-import '../../themes/theme.dart';
+import 'package:vital_circle/shared/shared.dart';
+import 'package:vital_circle/themes/theme.dart';
 
 const LOREM_IPSUM =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse aliquet fringilla urna vel lacinia. Ut pulvinar dapibus augue, sed tempor lorem efficitur non. Morbi id felis eget augue feugiat dapibus sit amet a neque. Curabitur lectus sapien, semper ut ex quis, bibendum pulvinar diam. Curabitur rutrum dictum lacus, ac semper magna. Suspendisse efficitur venenatis erat, eu ultrices sapien mollis et. Nulla facilisi. Phasellus ullamcorper velit ut viverra vehicula. Mauris vitae augue tellus. Mauris vel semper felis. Duis tincidunt consequat metus at laoreet. Donec velit purus, lobortis vitae felis ut, finibus pharetra ante. Morbi pellentesque tortor odio, et malesuada sapien tincidunt sed. Donec non blandit sapien. Proin ac ex quis risus molestie luctus. Cras eu augue semper, auctor purus eu, mollis tellus. Integer finibus sapien sit amet risus cursus gravida. Fusce tempor id magna sed cursus. Integer facilisis vulputate quam sed auctor. Quisque tincidunt ipsum tellus, non venenatis libero fermentum non. Morbi suscipit condimentum risus, et rhoncus quam. Aliquam eu nunc lectus. Sed faucibus elit vel sollicitudin aliquet. In hac habitasse platea dictumst. Suspendisse eget justo et enim posuere pharetra. Donec et eleifend orci. In tempor metus ut facilisis varius. Integer et nulla luctus, consectetur orci ut, varius sem. Proin facilisis, orci in imperdiet vulputate, justo sem venenatis ante, ut laoreet magna quam a lacus. Duis lacus augue, ultrices sit amet purus sit amet, rhoncus posuere sapien. Nulla ornare eget ante scelerisque faucibus. Pellentesque volutpat lorem sapien. In convallis sollicitudin vulputate. Quisque imperdiet, lectus in suscipit bibendum, enim erat eleifend odio, et molestie libero eros non urna. Nunc bibendum tincidunt magna, vel suscipit nibh dignissim ac. Vivamus arcu magna, suscipit et egestas quis, porta vitae metus. Pellentesque luctus eu sapien eu tristique. Nullam pharetra nibh libero, semper sagittis libero lacinia id. Ut vel eros ut elit tincidunt viverra ut ut nisi. Fusce facilisis ligula sem, eu ornare diam fermentum non. Fusce vitae porta lorem. Fusce sed fringilla erat. Pellentesque semper ut massa egestas viverra. Donec at ornare massa. Morbi eu auctor mauris. Pellentesque lacinia dui vel ligula elementum efficitur. Curabitur id eros magna. Phasellus aliquam lectus vitae orci ullamcorper sollicitudin non at elit. Nullam sit amet urna at quam hendrerit lobortis. Nam vitae convallis turpis, commodo viverra ipsum. Nullam malesuada metus mauris, in hendrerit lectus blandit sed. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque tempus, dui a scelerisque euismod, nulla nibh consequat nulla, id hendrerit velit dolor sed ex. Maecenas auctor metus sit amet sem rutrum ullamcorper. Vivamus sollicitudin leo sollicitudin, semper tellus eget, elementum odio. Cras aliquet sit amet nisi eget porttitor. Etiam venenatis scelerisque orci, congue porta mauris tempor tristique. Donec ultricies vitae lacus eget imperdiet. Nulla vel libero ut sem rutrum facilisis.';
 
 class LegalAgreementScreen extends StatelessWidget {
   const LegalAgreementScreen(
-      {@required this.title, @required this.content, @required this.onAccept, @required this.isProcessing});
+      {@required this.title,
+      @required this.content,
+      @required this.onAccept,
+      @required this.isProcessing});
 
   final String title;
   final String content;

--- a/lib/screens/onboarding/location-agreement.dart
+++ b/lib/screens/onboarding/location-agreement.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:vital_circle/themes/typography.dart';
 
-import '../../shared/shared.dart';
-import '../../themes/theme.dart';
+import 'package:vital_circle/shared/shared.dart';
+import 'package:vital_circle/themes/theme.dart';
 import 'location-agreement.vm.dart';
 
 class LocationAgreementScreen extends StatelessWidget {
@@ -26,7 +26,9 @@ class LocationAgreementScreen extends StatelessWidget {
                   padding: EdgeInsets.symmetric(vertical: Spacers.lg),
                 ),
                 const Expanded(
-                    child: Center(child: Text('TODO: some graphic and text explaining why to share their location.'))),
+                    child: Center(
+                        child: Text(
+                            'TODO: some graphic and text explaining why to share their location.'))),
                 const SizedBox(height: Spacers.md),
                 Row(
                   children: <Widget>[

--- a/lib/screens/onboarding/onboarding.vm.dart
+++ b/lib/screens/onboarding/onboarding.vm.dart
@@ -5,8 +5,8 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:vital_circle/services/services.dart';
 
-import '../../models/index.dart';
-import '../../routes.dart';
+import 'package:vital_circle/models/index.dart';
+import 'package:vital_circle/routes.dart';
 
 enum OnboardingSteps { PrivacyPolicy, TermsOfService, LocationSharing }
 
@@ -41,13 +41,19 @@ class OnboardingViewModel extends ChangeNotifier {
 
   Set<OnboardingSteps> _getSteps(User user) {
     final steps = <OnboardingSteps>{};
-    if (user == null || user.agreements == null || user.agreements.privacyPolicy == null) {
+    if (user == null ||
+        user.agreements == null ||
+        user.agreements.privacyPolicy == null) {
       steps.add(OnboardingSteps.PrivacyPolicy);
     }
-    if (user == null || user.agreements == null || user.agreements.termsOfService == null) {
+    if (user == null ||
+        user.agreements == null ||
+        user.agreements.termsOfService == null) {
       steps.add(OnboardingSteps.TermsOfService);
     }
-    if (user == null || user.agreements == null || user.agreements.locationSharing == null) {
+    if (user == null ||
+        user.agreements == null ||
+        user.agreements.locationSharing == null) {
       steps.add(OnboardingSteps.LocationSharing);
     }
     return steps;

--- a/lib/screens/onboarding/privacy-agreement.dart
+++ b/lib/screens/onboarding/privacy-agreement.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../shared/shared.dart';
+import 'package:vital_circle/shared/shared.dart';
 import 'legal.dart';
 import 'privacy-agreement.vm.dart';
 

--- a/lib/screens/onboarding/tos-agreement.dart
+++ b/lib/screens/onboarding/tos-agreement.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../shared/shared.dart';
+import 'package:vital_circle/shared/shared.dart';
 import 'legal.dart';
 import 'tos-agreement.vm.dart';
 

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -1,5 +1,6 @@
 export './boot/boot.dart';
 export './checkin/checkin.dart';
+export './checkin/checkin_done.dart';
 export './checkin_history/checkin_history.dart';
 export './dashboard/dashboard.dart';
 export './onboarding/onboarding.dart';

--- a/lib/services/auth/auth_provider_type_cache.dart
+++ b/lib/services/auth/auth_provider_type_cache.dart
@@ -1,7 +1,7 @@
 import 'package:vital_circle/constants/local_storage_key.dart';
 import 'package:vital_circle/enums/auth_provider_type.dart';
 
-import '../local_storage.service.dart';
+import 'package:vital_circle/services/local_storage.service.dart';
 
 /// Typed access to persistent storage for the last authentication provider type
 /// that was used to successfully authenticate.

--- a/lib/services/firestore/checkin.api.dart
+++ b/lib/services/firestore/checkin.api.dart
@@ -4,15 +4,14 @@ import 'package:vital_circle/models/index.dart';
 import 'package:vital_circle/services/services.dart';
 import 'package:vital_circle/utils/firestore_path.dart';
 
-import '../../models/index.dart';
-
 class CheckinApi {
   final _log = LogService.zone(LogZone.FIRESTORE);
 
   Stream<List<Checkin>> streamCheckins(String userId) {
     final path = FirestorePath.checkinsPath(userId);
     return Firestore.instance.collection(path).snapshots().map((query) {
-      _log.debug('streamCheckins', <String, dynamic>{'userId': userId, 'count': query.documents.length});
+      _log.debug('streamCheckins',
+          <String, dynamic>{'userId': userId, 'count': query.documents.length});
       return query.documents
           .where((doc) => doc.data != null)
           .map((doc) => Checkin.fromFirestore(doc.documentID, doc.data))
@@ -20,14 +19,17 @@ class CheckinApi {
     });
   }
 
-  Stream<List<Checkin>> streamCheckinsForTimeRange(String userId, DateTime start, DateTime end) {
+  Stream<List<Checkin>> streamCheckinsForTimeRange(
+      String userId, DateTime start, DateTime end) {
     final path = FirestorePath.checkinsPath(userId);
     return Firestore.instance
         .collection(path)
-        .where(CheckinProperty.TIMESTAMP, isGreaterThanOrEqualTo: start, isLessThanOrEqualTo: end)
+        .where(CheckinProperty.TIMESTAMP,
+            isGreaterThanOrEqualTo: start, isLessThanOrEqualTo: end)
         .snapshots()
         .map((query) {
-      _log.debug('streamCheckinsForTimeRange', <String, dynamic>{'userId': userId, 'count': query.documents.length});
+      _log.debug('streamCheckinsForTimeRange',
+          <String, dynamic>{'userId': userId, 'count': query.documents.length});
       return query.documents
           .where((doc) => doc.data != null)
           .map((doc) => Checkin.fromFirestore(doc.documentID, doc.data))
@@ -42,7 +44,11 @@ class CheckinApi {
       return null;
     }
     final checkin = Checkin.fromFirestore(doc.documentID, doc.data);
-    _log.debug('getCheckin', <String, dynamic>{'userId': userId, 'checkinId': checkinId, 'Checkin': doc.data});
+    _log.debug('getCheckin', <String, dynamic>{
+      'userId': userId,
+      'checkinId': checkinId,
+      'Checkin': doc.data
+    });
     return checkin;
   }
 
@@ -60,6 +66,7 @@ class CheckinApi {
     final data = checkin.toFirestore();
     final doc = Firestore.instance.document(path);
     doc.updateData(data);
-    _log.debug('updateCheckin', <String, dynamic>{'userId': userId, 'data': data});
+    _log.debug(
+        'updateCheckin', <String, dynamic>{'userId': userId, 'data': data});
   }
 }

--- a/lib/services/firestore/user.api.dart
+++ b/lib/services/firestore/user.api.dart
@@ -4,16 +4,21 @@ import 'package:vital_circle/models/index.dart';
 import 'package:vital_circle/services/services.dart';
 import 'package:vital_circle/utils/firestore_path.dart';
 
-import '../../models/index.dart';
-
 class UserApi {
   final _log = LogService.zone(LogZone.FIRESTORE);
 
   Stream<User> streamUser(String id) {
     final userPath = FirestorePath.userPath(id);
-    return Firestore.instance.document(userPath).snapshots().where((snapshot) => snapshot != null).map((snapshot) {
-      _log.debug('streamLocation', <String, dynamic>{'path': snapshot.reference.path});
-      return snapshot.data != null ? User.fromFirestore(snapshot.documentID, snapshot.data) : null;
+    return Firestore.instance
+        .document(userPath)
+        .snapshots()
+        .where((snapshot) => snapshot != null)
+        .map((snapshot) {
+      _log.debug(
+          'streamLocation', <String, dynamic>{'path': snapshot.reference.path});
+      return snapshot.data != null
+          ? User.fromFirestore(snapshot.documentID, snapshot.data)
+          : null;
     });
   }
 
@@ -28,14 +33,17 @@ class UserApi {
     return user;
   }
 
-  Future<void> updatePrivacyAgreement(String id) => _updateAgreement(id, AgreementsProperty.PRIVACY_POLICY_DATE);
+  Future<void> updatePrivacyAgreement(String id) =>
+      _updateAgreement(id, AgreementsProperty.PRIVACY_POLICY_DATE);
   Future<void> updateTermsOfServiceAgreement(String id) =>
       _updateAgreement(id, AgreementsProperty.TERMS_OF_SERVICE_DATE);
 
   Future<void> _updateAgreement(String id, String agreementKey) async {
     final userPath = FirestorePath.userPath(id);
     final data = <String, dynamic>{
-      UserProperty.AGREEMENTS: <String, dynamic>{agreementKey: FieldValue.serverTimestamp()}
+      UserProperty.AGREEMENTS: <String, dynamic>{
+        agreementKey: FieldValue.serverTimestamp()
+      }
     };
     _log.debug('updateAgreement', <String, dynamic>{'id': id, 'data': data});
     await Firestore.instance.document(userPath).setData(data, merge: true);
@@ -49,7 +57,8 @@ class UserApi {
         AgreementsProperty.LOCATION_SHARING_DATE: FieldValue.serverTimestamp()
       }
     };
-    _log.debug('updateLocationSharingAgreement', <String, dynamic>{'id': id, 'data': data});
+    _log.debug('updateLocationSharingAgreement',
+        <String, dynamic>{'id': id, 'data': data});
     await Firestore.instance.document(userPath).setData(data, merge: true);
   }
 }

--- a/lib/shared/app_bar.dart
+++ b/lib/shared/app_bar.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 
 class SharedAppBar extends AppBar {
-  SharedAppBar({Widget title, List<Widget> actions})
+  SharedAppBar({Widget title, List<Widget> actions, Widget leading})
       : super(
-          backgroundColor: Colors.transparent,
-          centerTitle: true,
-          elevation: 0,
-          title: title,
-          actions: actions,
-        );
+            backgroundColor: Colors.transparent,
+            centerTitle: true,
+            elevation: 0,
+            title: title,
+            actions: actions,
+            leading: leading);
 }

--- a/lib/shared/auth/auth_buttons.dart
+++ b/lib/shared/auth/auth_buttons.dart
@@ -4,7 +4,7 @@ import 'package:vital_circle/themes/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import '../base_widget.dart';
+import 'package:vital_circle/shared/base_widget.dart';
 import 'anonymous_sign_in.dart';
 import 'auth_buttons.vm.dart';
 import 'google_sign_in.dart';
@@ -24,19 +24,23 @@ class AuthButtons extends StatelessWidget {
               children: <Widget>[
                 SizedBox(
                     width: SOCIAL_BUTTON_WIDTH,
-                    child: GoogleSignInButton(onPressed: () async => _signIn(context, AuthProviderType.google, model))),
+                    child: GoogleSignInButton(
+                        onPressed: () async =>
+                            _signIn(context, AuthProviderType.google, model))),
                 const SizedBox(height: Spacers.sm),
                 SizedBox(
                     width: SOCIAL_BUTTON_WIDTH,
                     child: AnonymousSignInButton(
-                      onPressed: () async => _signIn(context, AuthProviderType.anonymous, model),
+                      onPressed: () async =>
+                          _signIn(context, AuthProviderType.anonymous, model),
                     ))
               ],
               mainAxisSize: MainAxisSize.min,
             ));
   }
 
-  Future<void> _signIn(BuildContext context, AuthProviderType providerType, AuthButtonsViewModel model) async {
+  Future<void> _signIn(BuildContext context, AuthProviderType providerType,
+      AuthButtonsViewModel model) async {
     try {
       onBusyToggle(true);
       if (!await model.signIn(context, providerType)) {
@@ -46,7 +50,9 @@ class AuthButtons extends StatelessWidget {
       onBusyToggle(false);
       String message = 'Failed to sign in.';
       if (error is PlatformException &&
-          error.code == SignInExceptionType.ERROR_ACCOUNT_EXISTS_WITH_DIFFERENT_CREDENTIAL) {
+          error.code ==
+              SignInExceptionType
+                  .ERROR_ACCOUNT_EXISTS_WITH_DIFFERENT_CREDENTIAL) {
         message = 'Account exists for a different sign in method.';
       }
       Scaffold.of(context).showSnackBar(SnackBar(

--- a/lib/shared/card/navigation_card.dart
+++ b/lib/shared/card/navigation_card.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+import '../../themes/theme.dart';
+import '../shared.dart';
+
+class NavigationCard extends StatelessWidget {
+  const NavigationCard(
+      {@required this.icon,
+      @required this.title,
+      this.subtitle,
+      this.routeName});
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final String routeName;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: AppColors.cardBorder),
+          borderRadius: const BorderRadius.all(Radius.circular(16)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Icon(icon),
+            const SizedBox(width: 16),
+            Expanded(
+              flex: 1,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(title, style: AppTypography.bodyBold),
+                  const SizedBox(height: 4),
+                  if (subtitle != null) WrappedText(child: Text(subtitle)),
+                ],
+              ),
+            )
+          ],
+        ),
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+      ),
+      onTap: routeName == null
+          ? null
+          : () {
+              Navigator.of(context).pushNamed(routeName);
+            },
+    );
+  }
+}

--- a/lib/shared/card/navigation_card.dart
+++ b/lib/shared/card/navigation_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../themes/theme.dart';
-import '../shared.dart';
+import 'package:vital_circle/themes/theme.dart';
+import 'package:vital_circle/shared/shared.dart';
 
 class NavigationCard extends StatelessWidget {
   const NavigationCard(

--- a/lib/shared/card/selection_card.dart
+++ b/lib/shared/card/selection_card.dart
@@ -1,0 +1,1 @@
+import 'package:flutter/material.dart';

--- a/lib/shared/card/selection_card.dart
+++ b/lib/shared/card/selection_card.dart
@@ -1,1 +1,47 @@
 import 'package:flutter/material.dart';
+
+import 'package:vital_circle/themes/theme.dart';
+import 'package:vital_circle/shared/shared.dart';
+
+class SelectionCard extends StatelessWidget {
+  const SelectionCard({@required this.icon, @required this.title});
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: AppColors.cardBorder),
+          borderRadius: const BorderRadius.all(Radius.circular(16)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Icon(icon),
+            const SizedBox(width: 16),
+            Expanded(
+              flex: 1,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(title, style: AppTypography.bodyBold),
+                  const SizedBox(height: 4),
+                  // if (subtitle != null) WrappedText(child: Text(subtitle)),
+                ],
+              ),
+            )
+          ],
+        ),
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+      ),
+      // onTap: routeName == null
+      //     ? null
+      //     : () {
+      //         Navigator.of(context).pushNamed(routeName);
+      //       },
+    );
+  }
+}

--- a/lib/shared/card/selection_card.dart
+++ b/lib/shared/card/selection_card.dart
@@ -3,45 +3,42 @@ import 'package:flutter/material.dart';
 import 'package:vital_circle/themes/theme.dart';
 import 'package:vital_circle/shared/shared.dart';
 
-class SelectionCard extends StatelessWidget {
-  const SelectionCard({@required this.icon, @required this.title});
+import '../../themes/colors.dart';
 
-  final IconData icon;
+class SelectionCard extends StatelessWidget {
+  const SelectionCard({@required this.title, this.selected = false});
+
   final String title;
+  final bool selected;
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      child: Container(
-        decoration: BoxDecoration(
-          border: Border.all(color: AppColors.cardBorder),
-          borderRadius: const BorderRadius.all(Radius.circular(16)),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Icon(icon),
-            const SizedBox(width: 16),
-            Expanded(
-              flex: 1,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(title, style: AppTypography.bodyBold),
-                  const SizedBox(height: 4),
-                  // if (subtitle != null) WrappedText(child: Text(subtitle)),
-                ],
-              ),
-            )
-          ],
-        ),
-        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: AppColors.cardBorder),
+        borderRadius: const BorderRadius.all(Radius.circular(16)),
       ),
-      // onTap: routeName == null
-      //     ? null
-      //     : () {
-      //         Navigator.of(context).pushNamed(routeName);
-      //       },
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Expanded(
+            flex: 1,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(title, style: AppTypography.bodyBold),
+                const SizedBox(height: 4),
+                // if (subtitle != null) WrappedText(child: Text(subtitle)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 16),
+          selected
+              ? Icon(Icons.check_circle)
+              : Icon(Icons.panorama_fish_eye, color: AppColors.cardBorder),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
     );
   }
 }

--- a/lib/shared/card/selection_card.dart
+++ b/lib/shared/card/selection_card.dart
@@ -26,11 +26,47 @@ class SelectionCard extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Text(title, style: AppTypography.bodyBold),
+                Text(title, style: AppTypography.bodyRegular1),
                 const SizedBox(height: 4),
                 // if (subtitle != null) WrappedText(child: Text(subtitle)),
               ],
             ),
+          ),
+          const SizedBox(width: 16),
+          selected
+              ? Icon(Icons.check_circle)
+              : Icon(Icons.panorama_fish_eye, color: AppColors.cardBorder),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+    );
+  }
+}
+
+class SelectionCardSmall extends StatelessWidget {
+  const SelectionCardSmall({@required this.title, this.selected = false});
+
+  final String title;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: AppColors.cardBorder),
+        borderRadius: const BorderRadius.all(Radius.circular(16)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(title, style: AppTypography.bodyRegular1),
+              const SizedBox(height: 4),
+              // if (subtitle != null) WrappedText(child: Text(subtitle)),
+            ],
           ),
           const SizedBox(width: 16),
           selected

--- a/lib/shared/shared.dart
+++ b/lib/shared/shared.dart
@@ -1,4 +1,6 @@
 export './auth/auth_buttons.dart';
+export './card/navigation_card.dart';
+export './card/selection_card.dart';
 export 'app_bar.dart';
 export 'base_widget.dart';
 export 'drawer/drawer.dart';


### PR DESCRIPTION
Most of my time was spent on the Checkin workflow and the widgets that are shared among them. I focused more heavily on a standardized UI than I did the viewmodel or the backend, as the current data model will likely need to be optimized to include JSON serialization in a future branch. Of note:

- I extracted the cards used in the dashboard screen into a shared widget, then modified this to the replace the symptom chips with "selection_cards"
- I implemented a PageController to allow horizontal swiping between the various symptom screens, and ensured that state remained active between each screen.
- I setup temporary lists for the "How are you feeling" and "Subjective Temperature" questions. These will need to be extracted into the data model
- I standardized package imports to always begin with "package:flutter_vista/...". This can be an issue with some pub packages (GetIt is a common example).

Hope that helps.